### PR TITLE
Added input style as a prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 React component that handles csv file input.  
 It handles file input and returns its content as a matrix.  
-  
+
 You can try it out in a [demo on Codesandbox](https://codesandbox.io/s/5058ln02lx).
 
 ## Installation
@@ -43,6 +43,7 @@ class App extends Component {
         onFileLoaded={this.handleForce}
         onError={this.handleDarkSideForce}
         inputId="ObiWan"
+        inputStyle={{color: 'red'}}
       />
     )
   }
@@ -61,9 +62,10 @@ ReactDOM.render(<App />, document.getElementById('root'))
 | onError       | function        |             | Error handling function.                                              |
 | parserOptions | object          | `{}`        | [PapaParse configuration](https://www.papaparse.com/docs#config) object override |
 | inputId       | string          |             | An id to be applied to the `<input>` element.                         |
+| inputStyle    | object          | `{}`        | Some style to be applied to the `<input>` element.                    |
 
 ### Results
 
-When the file has been loaded, it will parsed with [PapaParse](https://github.com/mholt/PapaParse) from a CSV formatted text to a matrix.  
+When the file has been loaded, it will be parsed with [PapaParse](https://github.com/mholt/PapaParse) from a CSV formatted text to a matrix.
 That matrix is returned to the parent component with `onFileLoaded` function (it will be passed as an argument).
 The second argument to `onFileLoaded` will be the filename provided

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,14 @@ const CSVReader = ({
   return (
     <div className={cssClass}>
       {label && <label htmlFor={inputId}>{label}</label>}
-      <input className="csv-input" type="file" id={inputId} style={inputStyle} accept="text/csv" onChange={e => handleChangeFile(e)} />
+      <input
+        className="csv-input"
+        type="file"
+        id={inputId}
+        style={inputStyle}
+        accept="text/csv"
+        onChange={e => handleChangeFile(e)}
+      />
     </div>
   );
 };

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const CSVReader = ({
   onFileLoaded,
   onError,
   inputId = null,
+  inputStyle = {},
   parserOptions = {}
 }) => {
   let fileContent = undefined;
@@ -32,7 +33,7 @@ const CSVReader = ({
   return (
     <div className={cssClass}>
       {label && <label htmlFor={inputId}>{label}</label>}
-      <input className="csv-input" type="file" id={inputId} accept="text/csv" onChange={e => handleChangeFile(e)} />
+      <input className="csv-input" type="file" id={inputId} style={inputStyle} accept="text/csv" onChange={e => handleChangeFile(e)} />
     </div>
   );
 };


### PR DESCRIPTION
## Description
These commits add the possibility to edit the `style` of the `input` component by passing a prop to it. This applies when we want to add styles in a simpler way, without needing to import any CSS.

## Changes
- [x] Improved Readme
- [x] Added `inputStyle` prop to main component