### PR TITLE
Support for "accept" file type options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import { string, func, element, oneOfType } from 'prop-types';
 const PapaParse = require('papaparse/papaparse.min.js');
 
 const CSVReader = ({
+  accept = '.csv, text/csv',
   cssClass = 'csv-reader-input',
   cssInputClass = 'csv-input',
   label,
@@ -39,7 +40,7 @@ const CSVReader = ({
         type="file"
         id={inputId}
         style={inputStyle}
-        accept=".csv, text/csv"
+        accept={accept}
         onChange={e => handleChangeFile(e)}
       />
     </div>


### PR DESCRIPTION
I use ".xlxs" files. Not sure about other file types but this seems to work. Would like to avoid having to fork for this functionality.
