### PR TITLE
Forward ref to the input

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,41 @@ ReactDOM.render(<App />, document.getElementById('root'))
 | inputId       | string          |                    | An id to be applied to the `<input>` element.                                    |
 | inputStyle    | object          | `{}`               | Some style to be applied to the `<input>` element.                               |
 | fileEncoding  | string          | `UTF-8`            | Encoding type of the input file                                                  |
+| ref           | React ref       |                    | Reference of the `<input>`                                                       |
 
 ### Results
 
 When the file has been loaded, it will be parsed with [PapaParse](https://github.com/mholt/PapaParse) from a CSV formatted text to a matrix.
 That matrix is returned to the parent component with `onFileLoaded` function (it will be passed as an argument).
 The second argument to `onFileLoaded` will be the filename provided
+
+## Replacing input by a different element
+
+```javascript
+import React, { useRef } from "react";
+import ReactDOM from 'react-dom';
+import CSVReader from 'react-csv-reader';
+
+const App = props => {
+    const inputRef = useRef()
+    const upload = () => inputRef.current.click()
+    return (
+        <div>
+            <CSVReader
+                ref={inputRef}
+                onFileLoaded={console.log}
+                onError={console.log}
+                inputStyle={{ display: 'none' }}
+            />
+            <img
+                style={{ width: 48, height: 36 }}
+                alt="upload"
+                src="http://www.graphicssimplified.com/wp-content/uploads/2015/04/upload-cloud.png"
+                onClick={upload}
+            />
+        </div>
+    );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'))
+```

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { string, func, element, oneOfType } from 'prop-types';
+import { string, func, element, oneOfType, shape, instanceOf } from 'prop-types';
 const PapaParse = require('papaparse/papaparse.min.js');
 
-const CSVReader = ({
+const CSVReader = React.forwardRef(({
   accept = '.csv, text/csv',
   cssClass = 'csv-reader-input',
   cssInputClass = 'csv-input',
@@ -13,7 +13,7 @@ const CSVReader = ({
   inputStyle = {},
   fileEncoding = 'UTF-8',
   parserOptions = {}
-}) => {
+}, ref) => {
   let fileContent = undefined;
 
   const handleChangeFile = e => {
@@ -40,6 +40,7 @@ const CSVReader = ({
     <div className={cssClass}>
       {label && <label htmlFor={inputId}>{label}</label>}
       <input
+        ref={ref}
         className={cssInputClass}
         type="file"
         id={inputId}
@@ -49,7 +50,7 @@ const CSVReader = ({
       />
     </div>
   );
-};
+});
 
 CSVReader.propTypes = {
   cssClass: string,
@@ -57,7 +58,11 @@ CSVReader.propTypes = {
   label: oneOfType([string, element]),
   onFileLoaded: func.isRequired,
   onError: func,
-  inputId: string
+  inputId: string,
+  ref: oneOfType([
+    func,
+    shape({ current: instanceOf(Element) })
+  ])
 };
 
 export default CSVReader;


### PR DESCRIPTION
Forwarding the ref to the input allows to change the input element with any other element. To do so the existing input needs to be hidden and when a click event is triggered on the desired element simulate a click event to the input's ref.