### PR TITLE
Add a name attribute to the file input

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![a11y axe](https://img.shields.io/badge/a11y-tested-brightgreen)
 ![TypeScript Support](https://img.shields.io/badge/TypeScript-Support-blue)
 
-React component that handles csv file input.  
+React component that handles csv file input.
 It handles file input and returns its content as a matrix.
 
 Docs: [nzambello.github.io/react-csv-reader](https://nzambello.github.io/react-csv-reader/)
@@ -80,6 +80,7 @@ class App extends Component {
         onError={this.handleDarkSideForce}
         parserOptions={papaparseOptions}
         inputId="ObiWan"
+        inputName="ObiWan"
         inputStyle={{color: 'red'}}
       />
     )
@@ -102,6 +103,7 @@ ReactDOM.render(<App />, document.getElementById('root'))
 | onError       | function        |                          | Error handling function.                                                         |
 | parserOptions | object          | `{}`                     | [PapaParse configuration](https://www.papaparse.com/docs#config) object override |
 | inputId       | string          | `react-csv-reader-input` | An id to be applied to the `<input>` element.                                    |
+| inputName     | string          | `react-csv-reader-input` | A name attribute to be applied to the `<input>` element.                         |
 | inputStyle    | object          | `{}`                     | Some style to be applied to the `<input>` element.                               |
 | fileEncoding  | string          | `UTF-8`                  | Encoding type of the input file.                                                 |
 | disabled      | boolean         | `false`                  | Set input disabled attribute.                                                    |

--- a/src/__snapshots__/index.test.tsx.snap
+++ b/src/__snapshots__/index.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`CSVReader is being rendered 1`] = `
     className="custom-csv-input"
     disabled={true}
     id="react-csv-reader"
+    name="react-csv-reader"
     onChange={[Function]}
     style={
       Object {

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -23,6 +23,7 @@ const csvReader = (
     cssLabelClass="custom-csv-label"
     fileEncoding="iso-8859-1"
     inputId="react-csv-reader"
+    inputName="react-csv-reader"
     inputStyle={{ color: 'red' }}
     label="CSV input label text"
     onError={e => console.error(e)}

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -78,6 +78,14 @@ describe('Testing CSVReader props:', () => {
     expect(inputNode.getAttribute('id')).toBe(inputId)
   })
 
+  test('has inputName prop set', () => {
+    const inputName = 'react-csv-reader'
+    const { getByLabelText } = render(csvReader)
+    const inputNode = getByLabelText('CSV input label text')
+
+    expect(inputNode.getAttribute('name')).toBe(inputName)
+  })
+
   test('has label prop set', () => {
     const { getByLabelText } = render(csvReader)
     const inputNode = getByLabelText('CSV input label text')

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,7 +31,7 @@ const CSVReader: React.FC<CSVReaderProps> = ({
   cssLabelClass = 'csv-label',
   fileEncoding = 'UTF-8',
   inputId = 'react-csv-reader-input',
-  inputName= 'react-csv-reader-input'
+  inputName= 'react-csv-reader-input',
   inputStyle = {},
   label,
   onError,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,7 @@ export interface CSVReaderProps {
   cssLabelClass?: string
   fileEncoding?: string
   inputId?: string
+  inputName?: string
   inputStyle?: object
   label?: string | React.ReactNode
   onError?: (error: Error) => void
@@ -30,6 +31,7 @@ const CSVReader: React.FC<CSVReaderProps> = ({
   cssLabelClass = 'csv-label',
   fileEncoding = 'UTF-8',
   inputId = 'react-csv-reader-input',
+  inputName= 'react-csv-reader-input'
   inputStyle = {},
   label,
   onError,
@@ -69,6 +71,7 @@ const CSVReader: React.FC<CSVReaderProps> = ({
         className={cssInputClass}
         type="file"
         id={inputId}
+        name={inputName}
         style={inputStyle}
         accept={accept}
         onChange={e => handleChangeFile(e)}
@@ -85,6 +88,7 @@ CSVReader.propTypes = {
   cssLabelClass: PropTypes.string,
   fileEncoding: PropTypes.string,
   inputId: PropTypes.string,
+  inputName: PropTypes.string,
   inputStyle: PropTypes.object,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   onError: PropTypes.func,


### PR DESCRIPTION
Sometimes we would need the name attribute to the CSV file input, in cases where the file needs to be submitted using a form. So I have a scenario wherein the parsed data from the `onFileLoaded` callback is used to display a few information in the UI and do some basic validity checks in the attached file. However to finally submit the form, as is the norm a `name` attribute is necessary to be set for the file input. 