### PR TITLE
chore: update peerDependencies to expect react 17 as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "16 - 17",
+    "react-dom": "16 - 17"
   },
   "dependencies": {
     "papaparse": "^5.3.0"

--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",
-    "react": "16 - 17",
-    "react-dom": "16 - 17"
+    "react": "^16.0.0 || ^17.0.0",
+    "react-dom": "^16.0.0 || ^17.0.0"
   },
   "dependencies": {
     "papaparse": "^5.3.0"


### PR DESCRIPTION
This PR is for this issue https://github.com/nzambello/react-csv-reader/issues/95
IDK the reason behind updating the `peerDependencies` but is breaking lots of projects using React 17.