### PR TITLE
fix: PropTypes error when giving RefObject to inputRef prop

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -67,7 +67,7 @@ describe('Testing CSVReader props:', () => {
   test('has cssLabelClass prop set', () => {
     const cssLabelClass = 'custom-csv-label'
     const { getByText } = render(csvReader)
-    const labelNode = getByText("CSV input label text");
+    const labelNode = getByText('CSV input label text')
 
     expect([...labelNode.classList]).toEqual([cssLabelClass])
   })
@@ -101,4 +101,14 @@ describe('Testing CSVReader props:', () => {
 
     expect(inputNode.getAttribute('disabled')).toBeDefined()
   })
+})
+
+test('prop-types error when give RefObject to inputRef', async () => {
+  console.error = jest.fn()
+  const inputRef: React.RefObject<HTMLInputElement> = { current: null }
+  React.createElement(CSVReader, {
+    inputRef,
+    onFileLoaded: (data, fileInfo) => console.dir(data, fileInfo),
+  })
+  expect(console.error).toHaveBeenCalledTimes(0)
 })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -105,7 +105,7 @@ CSVReader.propTypes = {
   inputId: PropTypes.string,
   inputName: PropTypes.string,
   inputStyle: PropTypes.object,
-  inputRef: PropTypes.func,
+  inputRef: PropTypes.oneOfType([PropTypes.func, PropTypes.exact({ current: PropTypes.instanceOf(HTMLInputElement) })]),
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   onError: PropTypes.func,
   onFileLoaded: PropTypes.func.isRequired,


### PR DESCRIPTION
If you pass `React.RefObject<HTMLInputElement>` created by `React.useRef()` etc. to inputRef prop, the error of prop-types will be displayed to console.
This PR solves its issue by fixing the definition of prop-types.
